### PR TITLE
Scripts to add test data to temporary alpha bucket

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-tensorflow[and-cuda]==2.19.0
+# tensorflow[and-cuda]==2.19.0 # Sure we don't need this
+awswrangler==3.12.1
+pandas==2.3.1
+

--- a/scripts/test-data.py
+++ b/scripts/test-data.py
@@ -1,0 +1,31 @@
+import awswrangler as wr
+import pandas as pd
+
+# Delete old experiements
+# wr.s3.delete_objects('s3://alpha-coat-moj-cur-v2-hourly/coat_cur_test_data/') 
+
+# Create database: run once only
+# wr.catalog.create_database(
+#     name='cloud_optimisation_and_accountabilty'
+# )
+
+# Read data from csv file in bucket
+df = wr.s3.read_csv(path='s3://alpha-coat-moj-cur-v2-hourly/cur_row_900000_to_1000000.csv')
+print( df.head(10))
+
+# Write data to parquet with partitions and create table in database
+# Every time this writes it appends data in partitions, so can duplicate data 
+wr.s3.to_parquet(
+    df=df,
+    path='s3://alpha-coat-moj-cur-v2-hourly/coat_cur_test_data/test_data.parquet',
+    dataset=True,
+    partition_cols=['billing_period'],
+    database='cloud_optimisation_and_accountabilty',
+    table='coat_cur_test_data',
+    dtype={
+        'bill_billing_period_end_date': 'timestamp',
+        'bill_billing_period_start_date': 'timestamp',
+        'billing_period': 'string'
+    }
+)
+


### PR DESCRIPTION
Scripts run manually via AP to read csv file and write out as partitioned parquet to our `alpha` bucket being used to hold test data representative of CUR data for use with CaDeT.